### PR TITLE
added network so disocrd bot can communicate with db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - .:/home/node/app
       - node_modules:/home/node/app/node_modules
     networks:
-      - app-network
+      - chastilock-network
   db:
     image: mysql:8
     container_name: chastilock-backend-db
@@ -32,11 +32,11 @@ services:
     volumes:
       - dbdata:/var/lib/mysql
     networks:
-      - app-network
+      - chastilock-network
 
 networks:
-  app-network:
-    driver: bridge
+  chastilock-network:
+    external: true
 
 volumes:
   dbdata:


### PR DESCRIPTION
It works and can communicate with the Database and so can the discord bot (defined in a different repo). It is ready to be merged into develop but the following needs to be run on the backend:

```docker network create chastilock-network```

